### PR TITLE
Add a note to prevent confusion about this repo purpose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. note:: Configuration for the *current* (17 October 2015) plone.org infrastructure. For the *new* plone.org, look at `ploneorg.core`
+
 AI Team
 =======
 


### PR DESCRIPTION
The repo description still links to a non-existent docs page. I can't change that or include it in a pull request, so could whoever merges this please change it to something like:

> Configuration for the _current_ (17 October 2015) plone.org infrastructure. For the _new_ plone.org, look at `ploneorg.core`
